### PR TITLE
Expose KCM kerberos socket

### DIFF
--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -14,6 +14,9 @@
         "/share/man",
         "*.la", "*.a"
     ],
+    "finish-args" : [
+        "--filesystem=/run/.heim_org.h5l.kcm-socket"
+    ],
     "modules": [
         "shared-modules/dbus-glib/dbus-glib.json",
         {


### PR DESCRIPTION
This is the last missing piece to make kerberos work out of the box, at least on my machine. As per [bug 1673437](https://bugzilla.mozilla.org/show_bug.cgi?id=1673437), access to `/etc/krb5.conf` or some of the `KRB5*` environment variables could also be required, however that wasn't my case so I'm adding just this bare minimum.